### PR TITLE
Add 6.x solrconfig to solr 6.3 container

### DIFF
--- a/6.3/scripts/solr-create-core
+++ b/6.3/scripts/solr-create-core
@@ -7,12 +7,29 @@ if [[ ! -z $DEBUG ]]; then
 fi
 
 core=$1
+schema=$2
 
 if [[ -z "$core" ]]; then
     echo >&2 'Error. Core name have to be defined'
     exit 1
 fi
 
-echo "Creating core with a default configuration:"
-solr create_core -c "$core"
+rm -rf /tmp/schema
+mkdir -p /tmp/schema
+cd /tmp/schema
+
+if [[ "$schema" = 'drupal8' ]]; then
+    wget -nv https://ftp.drupal.org/files/projects/search_api_solr-8.x-1.0-beta1.tar.gz
+    tar xzf search_api_solr*
+    solr create_core -c "$core" -d ./search_api_solr/solr-conf/6.x/
+elif [[ "$schema" = 'drupal7' ]]; then
+    wget -nv https://ftp.drupal.org/files/projects/search_api_solr-7.x-1.11.tar.gz
+    tar xzf search_api_solr*
+    solr create_core -c "$core" -d ./search_api_solr/solr-conf/6.x/
+else
+    echo "Creating core with a default configuration:"
+    solr create_core -c "$core"
+fi
+
+rm -rf /tmp/schema
 echo 'Done!'


### PR DESCRIPTION
Add the same functions for 6.3 as there is for the 5.5 container.
Both versions of search_api supports 6.x configuration.